### PR TITLE
fix: remove deadlock in Iterator() and improve sorting performance

### DIFF
--- a/entry/sorting/sorting.go
+++ b/entry/sorting/sorting.go
@@ -27,11 +27,8 @@ func SortByClockID(a, b iface.IPFSLogEntry, resolveConflict func(a iface.IPFSLog
 	if comparedIDs == 0 {
 		return resolveConflict(a, b)
 	}
-	if comparedIDs < 0 {
-		return -1, nil
-	}
 
-	return 1, nil
+	return comparedIDs, nil
 }
 
 func First(_, _ iface.IPFSLogEntry) (int, error) {
@@ -108,13 +105,24 @@ func Compare(a, b iface.IPFSLogEntry) (int, error) {
 	return a.GetClock().Compare(b.GetClock()), nil
 }
 
-func Sort(compFunc func(a, b iface.IPFSLogEntry) (int, error), values []iface.IPFSLogEntry) {
-	sort.SliceStable(values, func(i, j int) bool {
-		ret, err := compFunc(values[i], values[j])
-		if err != nil {
-			fmt.Printf("error while comparing: %v\n", err)
-			return false
-		}
-		return ret < 0
-	})
+func Sort(compFunc func(a, b iface.IPFSLogEntry) (int, error), values []iface.IPFSLogEntry, reverse bool) {
+	if reverse {
+		sort.SliceStable(values, func(i, j int) bool {
+			ret, err := compFunc(values[i], values[j])
+			if err != nil {
+				fmt.Printf("error while comparing: %v\n", err)
+				return false
+			}
+			return ret > 0
+		})
+	} else {
+		sort.SliceStable(values, func(i, j int) bool {
+			ret, err := compFunc(values[i], values[j])
+			if err != nil {
+				fmt.Printf("error while comparing: %v\n", err)
+				return false
+			}
+			return ret < 0
+		})
+	}
 }

--- a/log_io.go
+++ b/log_io.go
@@ -62,7 +62,7 @@ func fromMultihash(ctx context.Context, services core_iface.CoreAPI, hash cid.Ci
 	})
 
 	if options.Length != nil && *options.Length > -1 {
-		sorting.Sort(sortFn, entries)
+		sorting.Sort(sortFn, entries, false)
 
 		entries = entrySlice(entries, -*options.Length)
 	}
@@ -113,7 +113,7 @@ func fromEntryHash(ctx context.Context, services core_iface.CoreAPI, hashes []ci
 
 	entries := all
 	if length > -1 {
-		sorting.Sort(sortFn, entries)
+		sorting.Sort(sortFn, entries, false)
 		entries = entrySlice(all, -length)
 	}
 
@@ -136,7 +136,7 @@ func fromJSON(ctx context.Context, services core_iface.CoreAPI, jsonLog *JSONLog
 		Timeout:      options.Timeout,
 	})
 
-	sorting.Sort(sorting.Compare, entries)
+	sorting.Sort(sorting.Compare, entries, false)
 
 	return &Snapshot{
 		ID:     jsonLog.ID,
@@ -179,7 +179,7 @@ func fromEntry(ctx context.Context, services core_iface.CoreAPI, sourceEntries [
 	combined := append(sourceEntries, entries...)
 	combined = append(combined, options.Exclude...)
 	uniques := entry.NewOrderedMapFromEntries(combined).Slice()
-	sorting.Sort(sorting.Compare, uniques)
+	sorting.Sort(sorting.Compare, uniques, false)
 
 	// Cap the result at the right size by taking the last n entries
 	var sliced []iface.IPFSLogEntry

--- a/test/log_load_test.go
+++ b/test/log_load_test.go
@@ -713,19 +713,19 @@ func TestLogLoad(t *testing.T) {
 			}
 
 			fetchOrder := l.Values().Slice()
-			sorting.Sort(sorting.Compare, fetchOrder)
+			sorting.Sort(sorting.Compare, fetchOrder, false)
 			require.Equal(t, entriesAsStrings(entry.NewOrderedMapFromEntries(fetchOrder)), expectedData)
 
 			reverseOrder := l.Values().Slice()
 			sorting.Reverse(reverseOrder)
-			sorting.Sort(sorting.Compare, reverseOrder)
+			sorting.Sort(sorting.Compare, reverseOrder, false)
 			require.Equal(t, entriesAsStrings(entry.NewOrderedMapFromEntries(reverseOrder)), expectedData)
 
 			hashOrder := l.Values().Slice()
 			sorting.Sort(func(a, b iface.IPFSLogEntry) (int, error) {
 				return strings.Compare(a.GetHash().String(), b.GetHash().String()), nil
-			}, hashOrder)
-			sorting.Sort(sorting.Compare, hashOrder)
+			}, hashOrder, false)
+			sorting.Sort(sorting.Compare, hashOrder, false)
 			require.Equal(t, entriesAsStrings(entry.NewOrderedMapFromEntries(hashOrder)), expectedData)
 
 			var partialLog []iface.IPFSLogEntry
@@ -761,15 +761,15 @@ func TestLogLoad(t *testing.T) {
 			expectedData := testLog.ExpectedData
 
 			fetchOrder := l.Values().Slice()
-			sorting.Sort(sorting.Compare, fetchOrder)
+			sorting.Sort(sorting.Compare, fetchOrder, false)
 			require.Equal(t, entriesAsStrings(entry.NewOrderedMapFromEntries(fetchOrder)), expectedData)
 
 			for i := 0; i < 1000; i++ {
 				randomOrder := l.Values().Slice()
 				sorting.Sort(func(a, b iface.IPFSLogEntry) (int, error) {
 					return rand.Int(), nil
-				}, randomOrder)
-				sorting.Sort(sorting.Compare, randomOrder)
+				}, randomOrder, false)
+				sorting.Sort(sorting.Compare, randomOrder, false)
 
 				require.Equal(t, entriesAsStrings(entry.NewOrderedMapFromEntries(randomOrder)), expectedData)
 			}


### PR DESCRIPTION
[Change Description]
- Fix dead lock due to missing unlock in case of invalid input parameter in Iterator()
- Improve sorting + reverse into one function
- improve traverse() : reduce the number of sort & reverse.

[Ticket]
None

[Test]
run again tests

[CheckList]
None
Signed-off-by: phanquy <phanhuynhquy@gmail.com>